### PR TITLE
Add iOS support and document libjxl CPU architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.1
+
+* Document architecture: CocoaPods `JxlCoder` → libjxl (CPU/SIMD), not GPU.
+* Add iOS plugin registration mirroring the macOS method-channel API.
+* Clarify platform support matrix and Windows/Linux/Android roadmap.
+
 ## 0.1.0
 
 add two functions to avoid overhead between Dart and Swift

--- a/README.md
+++ b/README.md
@@ -1,15 +1,52 @@
 # JpegXL encoding and decoding for Flutter
 
+Thin Flutter plugin that wraps [awxkee/JxlCoder](https://github.com/awxkee/jxl-coder-swift)
+(`pod 'JxlCoder'`) for **JPEG ↔ JPEG XL** conversion.
+
+## Platforms
+
+| Platform | Status | Backend |
+|----------|--------|---------|
+| macOS 12+ | Supported | CocoaPods `JxlCoder` → **libjxl** (CPU / SIMD) |
+| iOS 13+ | Supported (this PR) | Same CocoaPods `JxlCoder` → **libjxl** |
+| Android | Not yet | Likely [awxkee/jxl-coder](https://github.com/awxkee/jxl-coder) or `libjxl` NDK |
+| Windows / Linux | Not yet | Needs `dart:ffi` (or CMake plugin) binding to **libjxl** |
+| Web | Not practical | No shipping browser JXL encode API for this use case |
+
+## Important: this is not a GPU codec
+
+- **libjxl has no production CUDA / Metal / Vulkan path** (see [libjxl#1134](https://github.com/libjxl/libjxl/issues/1134)). Speedups land as **CPU SIMD + multithreading**.
+- This plugin only exposes **JPEG bytes ↔ JXL bytes** (transcode), not RGBA encode/decode helpers for custom canvases.
+- Flutter/`dart:ui` image decode (`instantiateImageCodecWithSize`) is also **native CPU** codecs (often libjpeg-turbo), not a general GPU encode/decode pipeline. Impeller/Flutter GPU is for **rasterization**, not photo codecs.
+
+If you need faster interactive previews in an app, prefer: downsample-during-decode, smaller preview long-edge, avoid JXL on the hot path, and cache framed JPEGs — not “GPU JXL”.
+
 ## Usage
 
-``` Dart
-    Uint8List jpegData = await file.readAsBytes();
-    final Uint8List? jxlData = await JxlCoder.jpegToJxl(jpegData);
+```dart
+Uint8List jpegData = await file.readAsBytes();
+final Uint8List? jxlData = await JxlCoder.jpegToJxl(jpegData);
 
-    Uint8List jxlData = await file.readAsBytes();
-    final Uint8List? jpegData = await JxlCoder.jxlToJpeg(jxlData);
+Uint8List jxlData = await file.readAsBytes();
+final Uint8List? jpegData = await JxlCoder.jxlToJpeg(jxlData);
 
-    await JxlCoder.saveJpegAsJxl(inputFile.path, outputFile.path);
-
-    await JxlCoder.saveJxlAsJpeg(inputFile.path, outputFile.path);
+await JxlCoder.saveJpegAsJxl(inputFile.path, outputFile.path);
+await JxlCoder.saveJxlAsJpeg(inputFile.path, outputFile.path);
 ```
+
+## Depend on a fork (until a release includes iOS)
+
+```yaml
+dependencies:
+  jxl_coder:
+    git:
+      url: https://github.com/AMDphreak/flutter-jxl-coder.git
+      ref: multiplatform-ios-docs  # or main after merge
+```
+
+## Roadmap (Windows / Linux / Android)
+
+1. Federated plugin layout (`jxl_coder_platform_interface` + per-OS impls).
+2. Desktop: ship or discover `libjxl` shared libraries and call via FFI (`JxlEncoder` / `JxlDecoder`).
+3. Android: wrap awxkee’s Android AAR or link libjxl via CMake.
+4. Optional: expose RGBA encode/decode (not only JPEG transcode) for apps that frame canvases in Dart.

--- a/ios/Classes/JxlCoderPlugin.swift
+++ b/ios/Classes/JxlCoderPlugin.swift
@@ -1,0 +1,106 @@
+import Flutter
+import UIKit
+import JxlCoder
+
+public class JxlCoderPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(name: "jxl_coder", binaryMessenger: registrar.messenger())
+    let instance = JxlCoderPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "jpegToJxl":
+      if let args = call.arguments as? [String: Any],
+         let jpegData = args["jpegData"] as? FlutterStandardTypedData {
+        do {
+          let transcoded = try JXLCoder.transcode(jpegData: jpegData.data)
+          result(FlutterStandardTypedData(bytes: transcoded))
+        } catch {
+          result(FlutterError(
+            code: "TRANSCODE_ERROR",
+            message: "Failed to transcode JPEG to JXL",
+            details: error.localizedDescription
+          ))
+        }
+      } else {
+        result(FlutterError(
+          code: "INVALID_ARGUMENTS",
+          message: "jpegData is required",
+          details: nil
+        ))
+      }
+    case "jxlToJpeg":
+      if let args = call.arguments as? [String: Any],
+         let jxlData = args["jxlData"] as? FlutterStandardTypedData {
+        do {
+          let jpegData = try JXLCoder.inverse(jxlData: jxlData.data)
+          result(FlutterStandardTypedData(bytes: jpegData))
+        } catch {
+          result(FlutterError(
+            code: "INVERSE_ERROR",
+            message: "Failed to convert JXL to JPEG",
+            details: error.localizedDescription
+          ))
+        }
+      } else {
+        result(FlutterError(
+          code: "INVALID_ARGUMENTS",
+          message: "jxlData is required",
+          details: nil
+        ))
+      }
+    case "saveJpegAsJxl":
+      if let args = call.arguments as? [String: Any],
+         let inputPath = args["inputPath"] as? String,
+         let outputPath = args["outputPath"] as? String {
+        do {
+          let jpegData = try Data(contentsOf: URL(fileURLWithPath: inputPath))
+          let jxlData = try JXLCoder.transcode(jpegData: jpegData)
+          try jxlData.write(to: URL(fileURLWithPath: outputPath))
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "TRANSCODE_ERROR",
+            message: "Failed to transcode JPEG to JXL",
+            details: error.localizedDescription
+          ))
+        }
+      } else {
+        result(FlutterError(
+          code: "INVALID_ARGUMENTS",
+          message: "inputPath and outputPath are required",
+          details: nil
+        ))
+      }
+    case "saveJxlAsJpeg":
+      if let args = call.arguments as? [String: Any],
+         let inputPath = args["inputPath"] as? String,
+         let outputPath = args["outputPath"] as? String {
+        do {
+          let jxlData = try Data(contentsOf: URL(fileURLWithPath: inputPath))
+          let jpegData = try JXLCoder.inverse(jxlData: jxlData)
+          try jpegData.write(to: URL(fileURLWithPath: outputPath))
+          result(nil)
+        } catch {
+          result(FlutterError(
+            code: "INVERSE_ERROR",
+            message: "Failed to convert JXL to JPEG",
+            details: error.localizedDescription
+          ))
+        }
+      } else {
+        result(FlutterError(
+          code: "INVALID_ARGUMENTS",
+          message: "inputPath and outputPath are required",
+          details: nil
+        ))
+      }
+    case "getPlatformVersion":
+      result("iOS " + UIDevice.current.systemVersion)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+}

--- a/ios/jxl_coder.podspec
+++ b/ios/jxl_coder.podspec
@@ -5,7 +5,7 @@
 Pod::Spec.new do |s|
   s.name             = 'jxl_coder'
   s.version          = '0.1.1'
-  s.summary          = 'A Flutter plugin for the JxlCoder library on macOS.'
+  s.summary          = 'A Flutter plugin for the JxlCoder library on iOS.'
   s.description      = <<-DESC
 A plugin that provides JPEG XL (JXL) encoding and decoding using JxlCoder (libjxl).
                        DESC
@@ -15,10 +15,10 @@ A plugin that provides JPEG XL (JXL) encoding and decoding using JxlCoder (libjx
 
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
-  s.dependency 'FlutterMacOS'
+  s.dependency 'Flutter'
   s.dependency 'JxlCoder'
 
-  s.platform = :osx, '12.0'
+  s.platform = :ios, '13.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jxl_coder
-description: "JpegXL encoding and decoding for Flutter"
-version: 0.1.0
+description: "JpegXL encoding and decoding for Flutter (Apple platforms via libjxl)"
+version: 0.1.1
 repository: "https://github.com/stephane-archer/flutter-jxl-coder"
 
 environment:
@@ -17,53 +17,10 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^5.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' specifies the class (in Java, Kotlin, Swift, Objective-C, etc.)
-  # which should be registered in the plugin registry. This is required for
-  # using method channels.
-  # The Android 'package' specifies package in which the registered class is.
-  # This is required for using method channels on Android.
-  # The 'ffiPlugin' specifies that native code should be built and bundled.
-  # This is required for using `dart:ffi`.
-  # All these are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       macos:
         pluginClass: JxlCoderPlugin
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/to/asset-from-package
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/to/font-from-package
+      ios:
+        pluginClass: JxlCoderPlugin


### PR DESCRIPTION
## Summary
- Register the existing JPEG↔JXL method-channel API on **iOS** via CocoaPods `JxlCoder` (same backend as macOS).
- Document the real architecture: **libjxl CPU/SIMD**, not GPU; platform support matrix; Windows/Linux/Android roadmap.
- Bump to 0.1.1 and clarify podspecs.

## Context
Opened as follow-up to https://github.com/stephane-archer/flutter-jxl-coder/issues/2

InstaLay (and other desktop Flutter apps) need Windows/Linux eventually; this PR takes the easy Apple win (iOS) and sets expectations so maintainers/users do not chase a GPU path that libjxl does not offer.

## Test plan
- [ ] `pod lib lint ios/jxl_coder.podspec` / macOS podspec on an Apple machine
- [ ] Run `example/` on macOS: `jpegToJxl` / `jxlToJpeg` still work
- [ ] Run `example/` on iOS simulator/device after `pod install`
- [ ] Confirm `flutter pub get` resolves plugin for both `macos` and `ios` platforms

Note: I do not have an Apple build host in this contribution environment; iOS files mirror the macOS plugin 1:1 against the same `JXLCoder.transcode` / `inverse` API.